### PR TITLE
Add integration test environment

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,14 +39,14 @@ jobs:
           echo "::set-env name=IMAGE_EXISTS::true"
 
       - name: Terraform Init
-        uses: schramm-famm/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.12.13
           tf_actions_subcommand: init
           tf_actions_working_dir: ${{ env.TF_DIR }}
 
       - name: Terraform Apply
-        uses: schramm-famm/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.12.13
           tf_actions_subcommand: apply
@@ -60,7 +60,7 @@ jobs:
 
       - name: Terraform Destroy
         if: always()
-        uses: schramm-famm/terraform-github-actions@master
+        uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.12.13
           tf_actions_subcommand: destroy

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,79 @@
+name: Build & Integration Test
+on:
+  - push
+jobs:
+  testing:
+    name: Build & Integration Test
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TF_DIR: terraform
+      TF_VAR_name: ga-${{ github.run_id }}
+      TF_VAR_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      TF_VAR_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_rds_username: github
+      TF_VAR_rds_password: ${{ secrets.DB_PW }}
+      TF_VAR_container_tag: ${{ github.run_id }}
+      IMAGE_EXISTS: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          TAG: ${{ env.TF_VAR_container_tag }}
+        run: |
+          make docker-push
+          echo "::set-env name=IMAGE_EXISTS::true"
+
+      - name: Terraform Init
+        uses: schramm-famm/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: init
+          tf_actions_working_dir: ${{ env.TF_DIR }}
+
+      - name: Terraform Apply
+        uses: schramm-famm/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: apply
+          tf_actions_working_dir: ${{ env.TF_DIR }}
+
+      - name: Run integration tests
+        run: |
+          cd $TF_DIR
+          export HOST=$(terraform output host)
+          echo $HOST
+
+      - name: Terraform Destroy
+        if: always()
+        uses: schramm-famm/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: destroy
+          tf_actions_working_dir: ${{ env.TF_DIR }}
+
+      - name: Delete image from Amazon ECR
+        if: always()
+        run: |
+          if [ "$IMAGE_EXISTS" == "true" ]; then
+            aws ecr batch-delete-image --repository-name karen\
+            --image-ids imageTag=$TF_VAR_container_tag
+          fi
+
+      - name: Log out of Amazon ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,6 @@
 name: Build & Integration Test
 on:
-  - push
+  - pull_request
 jobs:
   testing:
     name: Build & Integration Test

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,24 @@
+name: Build & Unit Test
+on: [push]
+jobs:
+
+  build_and_unit_test:
+    name: Build & Unit Test
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        go mod download
+
+    - name: Build and unit test
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,17 @@
 *.so
 *.dylib
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+tmp/
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+*.tfvars
+*.tfstate
+*.tfstate.backup
+.terraform

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,7 +40,7 @@ resource "aws_security_group" "karen" {
 module "karen" {
   source          = "./modules/karen"
   name            = var.name
-  container_tag   = "0.1.0"
+  container_tag   = var.container_tag
   cluster_id      = module.ecs_cluster.cluster_id
   security_groups = [aws_security_group.karen.id]
   subnets         = module.ecs_base.vpc_public_subnets

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,62 @@
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.region
+}
+
+module "ecs_base" {
+  source = "github.com/schramm-famm/bespin//modules/ecs_base"
+  name   = var.name
+}
+
+module "ecs_cluster" {
+  source                  = "github.com/schramm-famm/bespin//modules/ecs_cluster"
+  name                    = var.name
+  security_group_ids      = [aws_security_group.karen.id]
+  subnets                 = module.ecs_base.vpc_public_subnets
+  ec2_instance_profile_id = module.ecs_base.ecs_instance_profile_id
+}
+
+resource "aws_security_group" "karen" {
+  name        = "${var.name}_allow_testing"
+  description = "Allow traffic necessary for integration testing"
+  vpc_id      = module.ecs_base.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "karen" {
+  source          = "./modules/karen"
+  name            = var.name
+  container_tag   = "0.1.0"
+  cluster_id      = module.ecs_cluster.cluster_id
+  security_groups = [aws_security_group.karen.id]
+  subnets         = module.ecs_base.vpc_public_subnets
+  db_location     = module.rds_instance.db_endpoint
+  db_username     = var.rds_username
+  db_password     = var.rds_password
+}
+
+module "rds_instance" {
+  source          = "github.com/schramm-famm/bespin//modules/rds_instance"
+  name            = var.name
+  engine          = "mariadb"
+  engine_version  = "10.2.21"
+  port            = 3306
+  master_username = var.rds_username
+  master_password = var.rds_password
+  vpc_id          = module.ecs_base.vpc_id
+  subnet_ids      = module.ecs_base.vpc_private_subnets
+}

--- a/terraform/modules/karen/main.tf
+++ b/terraform/modules/karen/main.tf
@@ -1,0 +1,79 @@
+data "aws_region" "karen" {}
+
+resource "aws_cloudwatch_log_group" "karen" {
+  name              = "${var.name}_karen"
+  retention_in_days = 1
+}
+
+resource "aws_ecs_task_definition" "karen" {
+  family       = "${var.name}_karen"
+  network_mode = "bridge"
+
+  container_definitions = <<EOF
+[
+  {
+    "name": "${var.name}_karen",
+    "image": "343660461351.dkr.ecr.us-east-2.amazonaws.com/karen:${var.container_tag}",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${aws_cloudwatch_log_group.karen.name}",
+            "awslogs-region": "${data.aws_region.karen.name}",
+            "awslogs-stream-prefix": "${var.name}"
+        }
+    },
+    "cpu": 10,
+    "memory": 128,
+    "essential": true,
+    "environment": [
+        {
+            "name": "KAREN_DB_LOCATION",
+            "value": "${var.db_location}"
+        },
+        {
+            "name": "KAREN_DB_USERNAME",
+            "value": "${var.db_username}"
+        },
+        {
+            "name": "KAREN_DB_PASSWORD",
+            "value": "${var.db_password}"
+        }
+    ],
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80,
+        "protocol": "tcp"
+      }
+    ]
+  }
+]
+EOF
+}
+
+resource "aws_elb" "karen" {
+  name            = "${var.name}-karen"
+  subnets         = var.subnets
+  security_groups = var.security_groups
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+}
+
+resource "aws_ecs_service" "karen" {
+  name            = "${var.name}_karen"
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.karen.arn
+
+  load_balancer {
+    elb_name       = aws_elb.karen.name
+    container_name = "${var.name}_karen"
+    container_port = 80
+  }
+
+  desired_count = 1
+}

--- a/terraform/modules/karen/output.tf
+++ b/terraform/modules/karen/output.tf
@@ -1,3 +1,3 @@
 output "elb_dns_name" {
-    value = aws_elb.karen.dns_name
+  value = aws_elb.karen.dns_name
 }

--- a/terraform/modules/karen/output.tf
+++ b/terraform/modules/karen/output.tf
@@ -1,0 +1,3 @@
+output "elb_dns_name" {
+    value = aws_elb.karen.dns_name
+}

--- a/terraform/modules/karen/variables.tf
+++ b/terraform/modules/karen/variables.tf
@@ -1,0 +1,40 @@
+variable "name" {
+  type        = string
+  description = "Name used to identify resources"
+}
+
+variable "container_tag" {
+  type        = string
+  description = "Tag of the karen container in the registry to be used"
+  default     = "latest"
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "ID of the ECS cluster that the karen service will run in"
+}
+
+variable "security_groups" {
+  type        = list(string)
+  description = "VPC security groups for the karen service load balancer"
+}
+
+variable "subnets" {
+  type        = list(string)
+  description = "VPC subnets for the karen service load balancer"
+}
+
+variable "db_location" {
+  type        = string
+  description = "Location (host) of the MariaDB server"
+}
+
+variable "db_username" {
+  type        = string
+  description = "Username for accessing the MariaDB server"
+}
+
+variable "db_password" {
+  type        = string
+  description = "Password for accessing the MariaDB server"
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,3 @@
+output "host" {
+  value = module.karen.elb_dns_name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,3 +28,9 @@ variable "rds_password" {
   type        = string
   description = "Password for the master RDS user"
 }
+
+variable "container_tag" {
+  type        = string
+  description = "Tag of the Docker container to be used in the karen container definition"
+  default     = "latest"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,30 @@
+variable "name" {
+  type        = string
+  description = "Name used to identify resources"
+}
+
+variable "access_key" {
+  type        = string
+  description = "AWS access key ID"
+}
+
+variable "secret_key" {
+  type        = string
+  description = "AWS secret access key"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy where resources will be deployed"
+  default     = "us-east-2"
+}
+
+variable "rds_username" {
+  type        = string
+  description = "Username for the master RDS user"
+}
+
+variable "rds_password" {
+  type        = string
+  description = "Password for the master RDS user"
+}


### PR DESCRIPTION
Resolves #10 

Created the `karen` Terraform module which is pretty much the same as the `pest-control` module. The top-level Terraform sets up an RDS instance using the `rds_instance` module from `bespin`.

Also added unit test and integration test workflows on pushes and pull requests, respectively.